### PR TITLE
add Reader.Append method

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -5,13 +5,14 @@
 package zip_test
 
 import (
-	"github.com/juju/zip"
 	"bytes"
 	"compress/flate"
 	"fmt"
 	"io"
 	"log"
 	"os"
+
+	"github.com/juju/zip"
 )
 
 func ExampleWriter() {

--- a/writer_test.go
+++ b/writer_test.go
@@ -87,6 +87,55 @@ func TestWriter(t *testing.T) {
 	}
 }
 
+func TestAppend(t *testing.T) {
+	// write a zip file
+	buf := new(bytes.Buffer)
+	w := NewWriter(buf)
+
+	for _, wt := range writeTests {
+		testCreate(t, w, &wt)
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// read it back
+	r, err := NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// append a file to it.
+	abuf := new(bytes.Buffer)
+	w = r.Append(abuf)
+
+	wt := WriteTest{
+		Name:   "foo",
+		Data:   []byte("Badgers, canines, weasels, owls, and snakes"),
+		Method: Store,
+		Mode:   0755,
+	}
+	testCreate(t, w, &wt)
+
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// read the whole thing back.
+	allBytes := append(buf.Bytes(), abuf.Bytes()...)
+
+	r, err = NewReader(bytes.NewReader(allBytes), int64(len(allBytes)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	writeTests := append(writeTests[1:], wt)
+	for i, wt := range writeTests {
+		testReadFile(t, r.File[i], &wt)
+	}
+}
+
 func TestWriterOffset(t *testing.T) {
 	largeData := make([]byte, 1<<17)
 	for i := range largeData {


### PR DESCRIPTION
This allows us to change an entry in a zip archive without
changing the original archive.
